### PR TITLE
Fix Plaguefall Map (green map)

### DIFF
--- a/MythicDungeonTools.lua
+++ b/MythicDungeonTools.lua
@@ -616,7 +616,7 @@ MDT.dungeonMaps = {
         [1] = "MistsOfTirneScithe",
     },
     [32] = {
-        [0] = "Plaguefall_B",
+        [0] = "Plaguefall",
         [1] = "Plaguefall",
         [2] = "Plaguefall_B",
     },


### PR DESCRIPTION
Hello,

I have a bug with this great tool. On Plaguefall, the map is not displayed. The game's locale is french in my case. We have a green texture like this :

![Capture](https://user-images.githubusercontent.com/38937004/102943475-760a7480-44b8-11eb-8a5a-ea830673764c.PNG)

The fix has been tested and works.

Thanks to the author of #179 for the fix.

I hope I did the fix with the right way for this PR.

Bye