### PR TITLE
Change Gluttonous Tick 2 group in Sanguine Depths

### DIFF
--- a/Shadowlands/SanguineDepths.lua
+++ b/Shadowlands/SanguineDepths.lua
@@ -321,7 +321,6 @@ MDT.dungeonEnemies[dungeonIndex] = {
             [2] = {
                 ["y"] = -157.88258064516;
                 ["x"] = 287.58709677419;
-                ["g"] = 4;
                 ["sublevel"] = 1;
             };
             [3] = {


### PR DESCRIPTION
Removed the group
Fix for issue #207

This tick can be pulled without pulling all the others