### PR TITLE
Applied the translation to some untranslated string.

### DIFF
--- a/DungeonEnemies.lua
+++ b/DungeonEnemies.lua
@@ -489,7 +489,7 @@ function MDT:DisplayBlipTooltip(blip, shown)
     ]]
     local occurence = (blip.data.isBoss and "") or blip.cloneIdx
 
-    local text = data.name.." "..occurence..group.."\n"..string.format(L["Level %d %s"],data.level,data.creatureType).."\n".. string.format(L["%s HP"],MDT:FormatEnemyHealth(health)).."\n"
+    local text = L[data.name].." "..occurence..group.."\n"..string.format(L["Level %d %s"],data.level,L[data.creatureType]).."\n".. string.format(L["%s HP"],MDT:FormatEnemyHealth(health)).."\n"
     local count = MDT:IsCurrentPresetTeeming() and data.teemingCount or data.count
     text = text ..L["Forces"]..": ".. MDT:FormatEnemyForces(count)
     local reapingText

--- a/EnemyInfo.lua
+++ b/EnemyInfo.lua
@@ -443,7 +443,7 @@ function MDT:UpdateEnemyInfoFrame(enemyIdx)
     if not enemyIdx then return end
     local data = MDT.dungeonEnemies[db.currentDungeonIdx][enemyIdx]
     local f = MDT.EnemyInfoFrame
-    f:SetTitle(data.name)
+    f:SetTitle(L[data.name])
     f.model:SetDisplayInfo(data.displayId or 39490)
     f.model:ResetModel()
 
@@ -468,7 +468,7 @@ function MDT:UpdateEnemyInfoFrame(enemyIdx)
 
     local enemies = {}
     for mobIdx,edata in ipairs(MDT.dungeonEnemies[db.currentDungeonIdx]) do
-        tinsert(enemies,mobIdx,edata.name)
+        tinsert(enemies,mobIdx,L[edata.name])
     end
     f.enemyDropDown:SetList(enemies)
     f.enemyDropDown:SetValue(enemyIdx)
@@ -528,7 +528,7 @@ function MDT:UpdateEnemyInfoData(enemyIdx)
     if not enemyIdx then return end
     local data = MDT.dungeonEnemies[db.currentDungeonIdx][enemyIdx]
     --data
-    f.enemyDataContainer.nameEditBox:SetText(data.name)
+    f.enemyDataContainer.nameEditBox:SetText(L[data.name])
     f.enemyDataContainer.nameEditBox.defaultText = data.name
     f.enemyDataContainer.idEditBox:SetText(data.id)
     f.enemyDataContainer.idEditBox.defaultText = data.id
@@ -540,7 +540,7 @@ function MDT:UpdateEnemyInfoData(enemyIdx)
     f.enemyDataContainer.healthEditBox:SetText(healthText)
     f.enemyDataContainer.healthEditBox.defaultText = healthText
 
-    f.enemyDataContainer.creatureTypeEditBox:SetText(data.creatureType)
+    f.enemyDataContainer.creatureTypeEditBox:SetText(L[data.creatureType])
     f.enemyDataContainer.creatureTypeEditBox.defaultText = data.creatureType
     f.enemyDataContainer.levelEditBox:SetText(data.level)
     f.enemyDataContainer.levelEditBox.defaultText = data.level


### PR DESCRIPTION
Some string (enemy name and creature type) was not translated in mouse tooltip and enemy info panel.