### PR TITLE
Modified the code to display by local monster name and creature type

### DIFF
--- a/DungeonEnemies.lua
+++ b/DungeonEnemies.lua
@@ -489,7 +489,7 @@ function MDT:DisplayBlipTooltip(blip, shown)
     ]]
     local occurence = (blip.data.isBoss and "") or blip.cloneIdx
 
-    local text = data.name.." "..occurence..group.."\n"..string.format(L["Level %d %s"],data.level,data.creatureType).."\n".. string.format(L["%s HP"],MDT:FormatEnemyHealth(health)).."\n"
+    local text = L[data.name].." "..occurence..group.."\n"..string.format(L["Level %d %s"],data.level,L[data.creatureType]).."\n".. string.format(L["%s HP"],MDT:FormatEnemyHealth(health)).."\n"
     local count = MDT:IsCurrentPresetTeeming() and data.teemingCount or data.count
     text = text ..L["Forces"]..": ".. MDT:FormatEnemyForces(count)
     local reapingText

--- a/EnemyInfo.lua
+++ b/EnemyInfo.lua
@@ -468,7 +468,7 @@ function MDT:UpdateEnemyInfoFrame(enemyIdx)
 
     local enemies = {}
     for mobIdx,edata in ipairs(MDT.dungeonEnemies[db.currentDungeonIdx]) do
-        tinsert(enemies,mobIdx,edata.name)
+        tinsert(enemies,mobIdx,L[edata.name])
     end
     f.enemyDropDown:SetList(enemies)
     f.enemyDropDown:SetValue(enemyIdx)
@@ -528,7 +528,7 @@ function MDT:UpdateEnemyInfoData(enemyIdx)
     if not enemyIdx then return end
     local data = MDT.dungeonEnemies[db.currentDungeonIdx][enemyIdx]
     --data
-    f.enemyDataContainer.nameEditBox:SetText(data.name)
+    f.enemyDataContainer.nameEditBox:SetText(L[data.name])
     f.enemyDataContainer.nameEditBox.defaultText = data.name
     f.enemyDataContainer.idEditBox:SetText(data.id)
     f.enemyDataContainer.idEditBox.defaultText = data.id
@@ -540,7 +540,7 @@ function MDT:UpdateEnemyInfoData(enemyIdx)
     f.enemyDataContainer.healthEditBox:SetText(healthText)
     f.enemyDataContainer.healthEditBox.defaultText = healthText
 
-    f.enemyDataContainer.creatureTypeEditBox:SetText(data.creatureType)
+    f.enemyDataContainer.creatureTypeEditBox:SetText(L[data.creatureType])
     f.enemyDataContainer.creatureTypeEditBox.defaultText = data.creatureType
     f.enemyDataContainer.levelEditBox:SetText(data.level)
     f.enemyDataContainer.levelEditBox.defaultText = data.level

--- a/MythicDungeonTools.lua
+++ b/MythicDungeonTools.lua
@@ -2147,8 +2147,8 @@ function MDT:UpdatePullTooltip(tooltip)
 						end
                         --topString
                         local newLine = "\n"
-                        local text = newLine..newLine..newLine..v.enemyData.name.." x"..v.enemyData.quantity..newLine
-                        text = text..string.format(L["Level %d %s"],v.enemyData.level,v.enemyData.creatureType)..newLine
+                        local text = newLine..newLine..newLine..L[v.enemyData.name].." x"..v.enemyData.quantity..newLine
+                        text = text..string.format(L["Level %d %s"],v.enemyData.level,L[v.enemyData.creatureType])..newLine
                         local boss = v.enemyData.isBoss or false
                         local health = MDT:CalculateEnemyHealth(boss,v.enemyData.baseHealth,db.currentDifficulty,v.enemyData.ignoreFortified)
                         text = text.. string.format(L["%s HP"],MDT:FormatEnemyHealth(health))..newLine


### PR DESCRIPTION
Hello, I am a user who enjoys Wow in Korea.
I think MTD is a great tool.
However, there are a few things to be desired, but in Korea, the name and creature type of monsters are often written in English, so it is often confusing.
So, I modified the code a little bit so that the name and creature type can be displayed by region, so please check it.

In addition, the notation of life is slightly different in Korea.
I don't know where to put this code.

I give you the notation of life in Korea as below, so I would appreciate it if you could consider adding a function that can be displayed differently by localization.

```lua
function MDT:FormatEnemyHealth(amount)
	amount = tonumber(amount)
    if not amount then return "" end
    if amount < 1e3 then
        return 0
    elseif amount >= 1e16 then
        return string.format("%.3f경", amount/1e16)
    elseif amount >= 1e12 then
        return string.format("%.3f조", amount/1e12)
    elseif amount >= 1e8 then
        return string.format("%.2f억", amount/1e8)
    elseif amount >= 1e4 then
        return string.format("%.1f만", amount/1e4)
    end
end
```