### PR TITLE
Fixing TazaveshUpper count as per patch 9.2.0.42423

### DIFF
--- a/Shadowlands/TazaveshLower.lua
+++ b/Shadowlands/TazaveshLower.lua
@@ -45,8 +45,6 @@ MDT.dungeonSubLevels[dungeonIndex] = {
     [4] = L["TazaveshFloor2"],
 }
 
-MDT.dungeonTotalCount[dungeonIndex] = {normal=160,teeming=192,teemingEnabled=true}
-
 MDT.mapPOIs[dungeonIndex] = {
    [1] = {
       [1] = {

--- a/Shadowlands/TazaveshUpper.lua
+++ b/Shadowlands/TazaveshUpper.lua
@@ -117,7 +117,7 @@ MDT.mapPOIs[dungeonIndex] = {
     };
  };
 
- MDT.dungeonTotalCount[dungeonIndex] = {normal=332,teeming=1000,teemingEnabled=true}
+ MDT.dungeonTotalCount[dungeonIndex] = {normal=346,teeming=1000,teemingEnabled=true}
  MDT.dungeonEnemies[dungeonIndex] = {
    [1] = {
       ["clones"] = {

--- a/python/combatLogReader/CombatLogReader.py
+++ b/python/combatLogReader/CombatLogReader.py
@@ -23,7 +23,7 @@ combatlog_cnames = ["timestampevent", "sourceGUID", "sourceName", "sourceFlags",
                     "overkill", "school", "resisted", "blocked", "absorbed", "critical", "glancing", "crushing",
                     "isOffHand"]
 
-CL = pd.read_csv("WoWCombatLog.txt", sep=",", header=None, names=combatlog_cnames, low_memory=False)
+CL = pd.read_csv("WoWCombatLog.txt", sep=",", header=None, names=combatlog_cnames, low_memory=False, on_bad_lines='skip')
 # Extracting the event from date and time, which are not comma separated
 timesplit = CL.timestampevent.str.split(" ")
 timesplitdf = pd.DataFrame.from_records(timesplit, columns=["date", "time", "remove", "event"])


### PR DESCRIPTION
Since mapping the dungeons they've changed the required enemy forces in Tazavesh Upper as reported by Laynz.
Tazavesh Lower and all mob count appears to remain the same.

Cleaned out a redundant, wrong and unused count from Tazavesh Lower. This changes nothing, but cleans the code.

A fix has also been added for the CombatLogReader that gave errors on some combatlogs.