### PR TITLE
Added Steath detect for Tracker Zo'Korss in Lower Tazavesh

### DIFF
--- a/Shadowlands/TazaveshLower.lua
+++ b/Shadowlands/TazaveshLower.lua
@@ -392,6 +392,7 @@ MDT.mapPOIs[dungeonIndex] = {
          [356929] = {};
          [356943] = {};
       };
+      ["stealthDetect"] = true;
       ["characteristics"] = {
          ["Taunt"] = true;
       };


### PR DESCRIPTION
Tracker Zo'korss in Lower Tazavesh (Streets) has stealth detect.