### PR TITLE
Adding Inspired Mobs to Tazavesh Upper and Lower

### DIFF
--- a/Shadowlands/TazaveshLower.lua
+++ b/Shadowlands/TazaveshLower.lua
@@ -227,7 +227,8 @@ MDT.mapPOIs[dungeonIndex] = {
             ["g"] = 5;
             ["sublevel"] = 1;
          };
-         [3] = {
+         [3] = {            
+            ["inspiring"] = true;
             ["y"] = -253.24857233171;
             ["x"] = 645.76793200298;
             ["g"] = 5;
@@ -917,7 +918,8 @@ MDT.mapPOIs[dungeonIndex] = {
             ["g"] = 15;
             ["sublevel"] = 1;
          };
-         [8] = {
+         [8] = {            
+            ["inspiring"] = true;
             ["y"] = -221.03494931265;
             ["x"] = 464.64980083189;
             ["g"] = 12;
@@ -1584,7 +1586,8 @@ MDT.mapPOIs[dungeonIndex] = {
    };
    [1] = {
       ["clones"] = {
-         [6] = {
+         [6] = {            
+            ["inspiring"] = true;
             ["y"] = -263.68958529496;
             ["x"] = 607.79378078901;
             ["g"] = 7;

--- a/Shadowlands/TazaveshUpper.lua
+++ b/Shadowlands/TazaveshUpper.lua
@@ -458,6 +458,7 @@ MDT.mapPOIs[dungeonIndex] = {
             ["sublevel"] = 1;
          };
          [76] = {
+            ["inspiring"] = true;
             ["y"] = -251.6745280159;
             ["x"] = 475.89391228458;
             ["g"] = 19;
@@ -916,6 +917,7 @@ MDT.mapPOIs[dungeonIndex] = {
             ["sublevel"] = 4;
          };
          [2] = {
+            ["inspiring"] = true;
             ["y"] = -359.43379694508;
             ["x"] = 475.99002161812;
             ["g"] = 29;
@@ -1417,6 +1419,7 @@ MDT.mapPOIs[dungeonIndex] = {
    [3] = {
       ["clones"] = {
          [1] = {
+            ["inspiring"] = true;
             ["y"] = -177.66299627614;
             ["x"] = 249.69831645553;
             ["g"] = 1;
@@ -1681,6 +1684,7 @@ MDT.mapPOIs[dungeonIndex] = {
             ["sublevel"] = 3;
          };
          [2] = {
+            ["inspiring"] = true;
             ["y"] = -364.03542012585;
             ["x"] = 434.889999698;
             ["g"] = 27;


### PR DESCRIPTION
Upper I believe is fully mapped, only right side of murloc room might have an inspired on that side
Lower is also fully mapped but then last room and right hand side corridor noone uses hasn't been checked