### PR TITLE
Plaguebelcher npcid correction

### DIFF
--- a/Shadowlands/Plaguefall.lua
+++ b/Shadowlands/Plaguefall.lua
@@ -2880,7 +2880,7 @@ MDT.dungeonEnemies[dungeonIndex] = {
             ["sublevel"] = 1;
          };
       };
-      ["id"] = 168396;
+      ["id"] = 173360;
       ["spells"] = {
          [326868] = {};
          [288865] = {};


### PR DESCRIPTION
The Plaguebelcher near third boss that gives 0 count has a different npcid: 173360.
This is the reason for the previous count mistake from the automatic script as suspected.