### PR TITLE
npcid and count update for Atal'ai Devoted now with id 170486

### DIFF
--- a/Shadowlands/DeOtherSide.lua
+++ b/Shadowlands/DeOtherSide.lua
@@ -1210,7 +1210,7 @@ MDT.dungeonEnemies[dungeonIndex] = {
             ["sublevel"] = 3;
          };
       };
-      ["id"] = 171333;
+      ["id"] = 170486;
       ["spells"] = {};
       ["characteristics"] = {
          ["Taunt"] = true;
@@ -1223,7 +1223,7 @@ MDT.dungeonEnemies[dungeonIndex] = {
          ["Imprison"] = true;
       };
       ["scale"] = 1;
-      ["count"] = 0;
+      ["count"] = 2;
       ["displayId"] = 97298;
       ["creatureType"] = "Humanoid";
       ["level"] = 60;


### PR DESCRIPTION
Turns out the mob does give 2 count the id has changed to 170486