### PR TITLE
Add Github Actions release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+# Based on the example from https://github.com/BigWigsMods/packager/wiki/GitHub-Actions-workflow
+
+name: Package and release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # specify the environment variables used by the packager, matching the secrets from the project on GitHub
+    env:
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+      WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}  # "GITHUB_TOKEN" is a secret always provided to the workflow
+                                                 # for your own token, the name cannot start with "GITHUB_"
+
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # gets git history for changelogs
+
+      # -w 0 disables WowInterface release
+      # -a 0 disables Wago release
+      - name: Package and release
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -w 0 -a 0

--- a/MythicDungeonTools.toc
+++ b/MythicDungeonTools.toc
@@ -15,6 +15,7 @@
 ## Notes-zhTW: 幫助你計算 M+ 的小怪%，規劃出最佳拉怪路線。
 ## OptionalDeps: ElvUI, LibStub, Ace3
 ## SavedVariables: MythicDungeonToolsDB
+## X-Curse-Project-ID: 288981
 
 libs\load_libs.xml
 init.lua


### PR DESCRIPTION
This uses the packager action provided by BigWigsMods to automatically
package releases and upload them to Curseforge and Github.

WowInterface and Wago releases are disabled for now, but could be easily added as well.

I think the only thing you still need to configure would be the secrets, which you can manage on Github.
See https://github.com/BigWigsMods/packager/wiki/GitHub-Actions-workflow for docs on how to manage the secrets.