### PR TITLE
v3.9.5.1

### DIFF
--- a/BattleForAzeroth/MechagonCity.lua
+++ b/BattleForAzeroth/MechagonCity.lua
@@ -795,6 +795,13 @@ MDT.dungeonEnemies[dungeonIndex] = {
         ["sublevel"] = 3;
         ["disguised"] = true;
       };
+      [9] = {
+        ["x"] = 645.50079417522;
+        ["y"] = -326.63569726352;
+        ["g"] = 12;
+        ["sublevel"] = 3;
+        ["disguised"] = true;
+      };
     };
   };
   [11] = {
@@ -1574,6 +1581,12 @@ MDT.dungeonEnemies[dungeonIndex] = {
         ["x"] = 604.9948324581;
         ["y"] = -200.00335993711;
         ["g"] = 12;
+        ["sublevel"] = 3;
+        ["shrouded"] = true;
+      };
+      [7] = {
+        ["x"] = 645.50079417522;
+        ["y"] = -326.63569726352;
         ["sublevel"] = 3;
         ["shrouded"] = true;
       };

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+v3.9.5.1
+- Added additional Nathrezim Infiltrators to Streets of Wonder and So'leah Gambit
+- fixed group linking of a few npcs
+- increased the size of Iron Docks Iron Stars 
 v3.9.5
 - S4 Dungeon Mapping complete including shrouded + inspiring
 - Added user assignable Iron Stars in Iron Docks

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,5 @@
 v3.9.5.1
-- Added additional Nathrezim Infiltrators to Streets of Wonder and So'leah Gambit
+- Added additional Nathrezim Infiltrators to Streets of Wonder, So'leah Gambit and Mechagon Workshop
 - fixed group linking of a few npcs
 - increased the size of Iron Docks Iron Stars 
 v3.9.5

--- a/MythicDungeonTools.toc
+++ b/MythicDungeonTools.toc
@@ -1,7 +1,7 @@
 ## Interface: 90205
 ## Title: Mythic Dungeon Tools
 ## Author: Nnoggie
-## Version: 3.9.5
+## Version: 3.9.5.1
 ## Notes: Tool for planning and optimizing Mythic+ dungeon runs
 ## Notes-deDE: Tool für das Planen und Optimieren von Mythic+ Dungeons
 ## Notes-esES: Herramienta para planificar y optimizar las rutas de mazmorras de Piedras Angulares

--- a/Shadowlands/TazaveshLower.lua
+++ b/Shadowlands/TazaveshLower.lua
@@ -727,7 +727,7 @@ MDT.dungeonEnemies[dungeonIndex] = {
       [1] = {
         ["x"] = 367.21836651258;
         ["y"] = -297.34471273293;
-        ["g"] = 22;
+        ["g"] = 21;
         ["sublevel"] = 1;
         ["scale"] = 1.4;
       };

--- a/Shadowlands/TazaveshLower.lua
+++ b/Shadowlands/TazaveshLower.lua
@@ -2158,6 +2158,20 @@ MDT.dungeonEnemies[dungeonIndex] = {
         ["scale"] = 0.8;
         ["shrouded"] = true;
       };
+      [11] = {
+        ["x"] = 446.75995518067;
+        ["y"] = -315.23678576772;
+        ["sublevel"] = 1;
+        ["scale"] = 0.8;
+        ["shrouded"] = true;
+      };
+      [12] = {
+        ["x"] = 478.0580361773;
+        ["y"] = -304.56370562997;
+        ["sublevel"] = 1;
+        ["scale"] = 0.8;
+        ["shrouded"] = true;
+      };
     };
   };
   [37] = {
@@ -2234,6 +2248,18 @@ MDT.dungeonEnemies[dungeonIndex] = {
       [4] = {
         ["x"] = 334.85501178455;
         ["y"] = -150.4005367927;
+        ["sublevel"] = 1;
+        ["disguised"] = true;
+      };
+      [5] = {
+        ["x"] = 478.0580361773;
+        ["y"] = -304.56370562997;
+        ["sublevel"] = 1;
+        ["disguised"] = true;
+      };
+      [6] = {
+        ["x"] = 446.75995518067;
+        ["y"] = -315.23678576772;
         ["sublevel"] = 1;
         ["disguised"] = true;
       };

--- a/Shadowlands/TazaveshUpper.lua
+++ b/Shadowlands/TazaveshUpper.lua
@@ -2440,7 +2440,7 @@ MDT.dungeonEnemies[dungeonIndex] = {
       [7] = {
         ["x"] = 538.99158745165;
         ["y"] = -264.28246427986;
-        ["g"] = 26;
+        ["g"] = 25;
         ["sublevel"] = 3;
         ["scale"] = 1.4;
         ["shrouded"] = true;
@@ -2466,6 +2466,13 @@ MDT.dungeonEnemies[dungeonIndex] = {
         ["g"] = 30;
         ["sublevel"] = 4;
         ["scale"] = 1.7;
+        ["shrouded"] = true;
+      };
+      [11] = {
+        ["x"] = 521.41160171385;
+        ["y"] = -133.3525102302;
+        ["sublevel"] = 4;
+        ["scale"] = 2;
         ["shrouded"] = true;
       };
     };
@@ -2503,6 +2510,30 @@ MDT.dungeonEnemies[dungeonIndex] = {
         ["g"] = 21;
         ["sublevel"] = 1;
         ["shrouded"] = true;
+        ["disguised"] = true;
+      };
+    };
+  };
+  [23] = {
+    ["name"] = "Shady Dealer";
+    ["id"] = 180315;
+    ["count"] = 0;
+    ["health"] = 0;
+    ["scale"] = 1;
+    ["displayId"] = 93594;
+    ["creatureType"] = "Humanoid";
+    ["level"] = 60;
+    ["characteristics"] = {
+      ["Taunt"] = true;
+    };
+    ["spells"] = {
+    };
+    ["clones"] = {
+      [1] = {
+        ["x"] = 521.41160171385;
+        ["y"] = -133.3525102302;
+        ["sublevel"] = 4;
+        ["scale"] = 2;
         ["disguised"] = true;
       };
     };

--- a/Shadowlands/TazaveshUpper.lua
+++ b/Shadowlands/TazaveshUpper.lua
@@ -2510,7 +2510,6 @@ MDT.dungeonEnemies[dungeonIndex] = {
         ["g"] = 21;
         ["sublevel"] = 1;
         ["shrouded"] = true;
-        ["disguised"] = true;
       };
     };
   };


### PR DESCRIPTION
v3.9.5.1
- Added additional Nathrezim Infiltrators to Streets of Wonder and So'leah Gambit
- fixed group linking of a few npcs
- increased the size of Iron Docks Iron Stars 
![image](https://user-images.githubusercontent.com/27819512/183160509-721145be-f04e-4c6d-8ea4-d8eb7ca50cc5.png)
![image](https://user-images.githubusercontent.com/27819512/183160564-b72de2f6-5d77-4996-a6e9-4d686c5de02a.png)
