### PR TITLE
update temple dungeon count

### DIFF
--- a/Dragonflight/TempleOfTheJadeSerpent.lua
+++ b/Dragonflight/TempleOfTheJadeSerpent.lua
@@ -15,7 +15,7 @@ MDT.dungeonSubLevels[dungeonIndex] = {
   [1] = L["TempleOfTheJadeSerpent"],
 }
 
-MDT.dungeonTotalCount[dungeonIndex] = { normal = 289, teeming = 1000, teemingEnabled = true }
+MDT.dungeonTotalCount[dungeonIndex] = { normal = 297, teeming = 1000, teemingEnabled = true }
 
 MDT.mapPOIs[dungeonIndex] = {};
 


### PR DESCRIPTION
Verifying TempleOfTheJadeSerpent.
- Total dungeon count has been updated: 289 -> 297