### PR TITLE
GameEvent and temple count update

### DIFF
--- a/Dragonflight/TempleOfTheJadeSerpent.lua
+++ b/Dragonflight/TempleOfTheJadeSerpent.lua
@@ -20,7 +20,7 @@ MDT.dungeonSubLevels[dungeonIndex] = {
   [1] = L["TempleOfTheJadeSerpent"],
 }
 
-MDT.dungeonTotalCount[dungeonIndex] = { normal = 297, teeming = 1000, teemingEnabled = true }
+MDT.dungeonTotalCount[dungeonIndex] = { normal = 410, teeming = 1000, teemingEnabled = true }
 
 MDT.mapPOIs[dungeonIndex] = {};
 

--- a/python/dungeon_mapper.py
+++ b/python/dungeon_mapper.py
@@ -295,6 +295,7 @@ def get_count_table(ID, db_files=None):
         107435: 77283,  # Gerenth the Vile, Court of Stars (Suspicious Noble)
         97202: 46333,  # Olmyr the Enlightened, Halls of Valor
         97219: 46333,  # Solsten, Halls of Valor
+        76057: 83187,  # Carrion Worm, Shadowmoon Burial Grounds
     }
     # For all game events, add a new row to the count table with the npcID
     for npcID, game_event in game_event_converter.items():


### PR DESCRIPTION
- Handle GameEvent for Shadowmoon Burial Grounds Carrion Worm
- Verifying Temple Of The Jade Serpent.
- Total dungeon count has been updated: 297 -> 410