### PR TITLE
Update progress bar when switching dungeons

### DIFF
--- a/MythicDungeonTools.lua
+++ b/MythicDungeonTools.lua
@@ -2490,6 +2490,7 @@ function MDT:UpdateToDungeon(dungeonIdx, ignoreUpdateMap, init)
   MDT:ZoomMapToDefault()
   --Colors the first pull in "Default" presets
   if db.currentPreset[db.currentDungeonIdx] == 1 then MDT:ColorPull() end
+  MDT:UpdateProgressbar()
 end
 
 function MDT:DeletePreset(index)


### PR DESCRIPTION
Currently when you switch dungeons using the dropdown the old progress bar is shown from whatever you were last viewing.