### PR TITLE
alter npc name pattern to account for both , and ;

### DIFF
--- a/python/update_dungeon_count.py
+++ b/python/update_dungeon_count.py
@@ -106,7 +106,10 @@ def update_count(match, dungeon_count_table):
         },  # Abstract Nullifier, Upper Karazhan
         115019: {"db_count": 3, "hardcoded_count": 6},  # Coldmist Widow, Lower Karazhan
         115020: {"db_count": 4, "hardcoded_count": 7},  # Arcanid, Lower Karazhan
-        45704: {"db_count": 3, "hardcoded_count": 0},  # Lurking Tempest, Vortex Pinnacle, cannot be killed
+        45704: {
+            "db_count": 3,
+            "hardcoded_count": 0,
+        },  # Lurking Tempest, Vortex Pinnacle, cannot be killed
     }
     if info["id"] in unexplainable_count.keys():
         npc_name = pattern_npc_name.search(match.group()).group(1)
@@ -309,7 +312,7 @@ if __name__ == "__main__":
     )
     pattern_dungeonTotalCount = re.compile(r"MDT\.dungeonTotalCount\[dungeonIndex\] .*")
     pattern_count_value = re.compile(r"normal = (\d+)")
-    pattern_npc_name = re.compile(r'\[\"name\"\] = "([^\n]+)";')
+    pattern_npc_name = re.compile(r'\[\"name\"\] = "([^\n]+)"(;|,)')
 
     # Make sure initial working directory is MythicDungeonTools
     while os.getcwd().__contains__("MythicDungeonTools") and not os.getcwd().endswith(


### PR DESCRIPTION
This fix solves the issue where the update_dungeon_count.py script breaks if lines end in , instead of ;.
The script now accepts either symbol to end a line.