### PR TITLE
get displayID from wowhead instead of wow.tools

### DIFF
--- a/python/dungeon_mapper.py
+++ b/python/dungeon_mapper.py
@@ -116,7 +116,7 @@ def get_additional_boss_info(name, UiMapIDs):
     """
     boss = db["journalencounter"][
         (
-            (db["journalencounter"].Name_lang == name)
+            (db["journalencounter"].Name_lang.str.contains(name))
             & (db["journalencounter"].UiMapID.isin(UiMapIDs))
         )
     ]

--- a/python/dungeon_mapper.py
+++ b/python/dungeon_mapper.py
@@ -630,7 +630,7 @@ def get_new_style_xy(sublevel, sublevel_group, group, group_counter):
 def print_progressbar(progress, total, size=60):
     x = int(size * progress / total)
     print(
-        f" Mapping: |{u'█'*x}{u'▁'*(size-x)}| {progress}/{total}", end="\r", flush=True
+        "\r", end=f" Mapping: |{u'█'*x}{u'▁'*(size-x)}| {progress}/{total} ", flush=True
     )
 
     if progress == total:

--- a/python/web_scraper.py
+++ b/python/web_scraper.py
@@ -21,30 +21,17 @@ def get_displayid_and_creaturetype(npcId):
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
     }
-    url = f"https://wow.tools/db/creature_api.php?id={npcId}"
-    creatureType_dict = {
-        1: "Beast",
-        2: "Dragonkin",
-        3: "Demon",
-        4: "Elemental",
-        5: "Giant",
-        6: "Undead",
-        7: "Humanoid",
-        8: "Critter",
-        9: "Mechanical",
-        10: "Not specified",
-        11: "Totem",
-        12: "Non-combat Pet",
-        13: "Gas Cloud",
-        14: "Wild Pet",
-        15: "Aberration",
-    }
+    url = f"https://www.wowhead.com/npc={npcId}"
     with requests.get(url, headers=headers) as r:
         time.sleep(1)
-        json = r.json()
-    displayID = json["CreatureDisplayInfoID[0]"]
-    creatureType = int(json["CreatureType"])
-    return displayID, creatureType_dict[creatureType]
+        if r.status_code == 200:
+            response = r.text
+            displayID = re.search(
+                r'data-mv-display-id="(.*)">View', str(response)
+            ).group(1)
+            creature_type = re.search(r"\]Type: ([^\[]*)\[", str(response)).group(1)
+
+    return displayID, creature_type
 
 
 def get_current_file_versions():


### PR DESCRIPTION
- fixes error trying to pull displayid from an outdated wow.tools api, by changing to wowhead
- fixes error when the boss npc id is contained in, but not equal to journalencounter boss name