### PR TITLE
Remove the statusbg element from all of the Ace frames created

### DIFF
--- a/MythicDungeonTools.lua
+++ b/MythicDungeonTools.lua
@@ -2738,6 +2738,7 @@ function MDT:MakeChatPresetImportFrame(frame)
       MDT.main_frame.sidePanelDeleteButton.text:SetTextColor(1, 0.8196, 0)
     end
   end)
+  chatImport.statustext:GetParent():Hide()
   chatImport.defaultText = L["Import Preset"]..":\n"
   chatImport.importLabel = AceGUI:Create("Label")
   chatImport.importLabel:SetText(chatImport.defaultText)
@@ -2797,6 +2798,7 @@ function MDT:MakePresetImportFrame(frame)
       MDT.main_frame.sidePanelDeleteButton.text:SetTextColor(1, 0.8196, 0)
     end
   end)
+  frame.presetImportFrame.statustext:GetParent():Hide()
 
   frame.presetImportLabel = AceGUI:Create("Label")
   frame.presetImportLabel:SetText(nil)
@@ -2913,6 +2915,7 @@ function MDT:MakePresetCreationFrame(frame)
       MDT.main_frame.sidePanelDeleteButton.text:SetTextColor(1, 0.8196, 0)
     end
   end)
+  frame.presetCreationFrame.statustext:GetParent():Hide()
 
   frame.PresetCreationEditbox = AceGUI:Create("EditBox")
   frame.PresetCreationEditbox:SetLabel(L["Preset Name"]..":")
@@ -3213,6 +3216,7 @@ function MDT:MakeCustomColorFrame(frame)
   frame.CustomColorFrame:SetHeight(220)
   frame.CustomColorFrame:EnableResize(false)
   frame.CustomColorFrame:SetLayout("Flow")
+  frame.CustomColorFrame.statustext:GetParent():Hide()
   frame:AddChild(frame.CustomColorFrame)
 
   --Slider to adjust number of different colors and remake the frame OnMouseUp
@@ -3270,6 +3274,7 @@ function MDT:MakeSettingsFrame(frame)
   frame.settingsFrame:SetHeight(250)
   frame.settingsFrame:EnableResize(false)
   frame.settingsFrame:SetLayout("Flow")
+  frame.settingsFrame.statustext:GetParent():Hide()
   MDT:FixAceGUIShowHide(frame.settingsFrame)
 
   frame.minimapCheckbox = AceGUI:Create("CheckBox")
@@ -3858,6 +3863,7 @@ function MDT:MakeRenameFrame(frame)
   frame.RenameFrame:SetCallback("OnClose", function(widget)
 
   end)
+  frame.RenameFrame.statustext:GetParent():Hide()
   frame.RenameFrame:Hide()
 
   local renameText
@@ -3910,6 +3916,7 @@ function MDT:MakeExportFrame(frame)
   frame.ExportFrame:EnableResize(false)
   frame.ExportFrame:SetLayout("Flow")
   frame.ExportFrame:SetCallback("OnClose", function(widget)
+  frame.ExportFrame.statustext:GetParent():Hide()
 
   end)
   frame.ExportFrameEditbox = AceGUI:Create("MultiLineEditBox")
@@ -3966,6 +3973,7 @@ function MDT:MakeDeleteConfirmationFrame(frame)
   frame.DeleteConfirmationFrame:SetCallback("OnClose", function(widget)
 
   end)
+  frame.DeleteConfirmationFrame.statustext:GetParent():Hide()
 
   frame.DeleteConfirmationFrame.label = AceGUI:Create("Label")
   frame.DeleteConfirmationFrame.label:SetWidth(390)
@@ -4003,6 +4011,7 @@ function MDT:MakeClearConfirmationFrame(frame)
   frame.ClearConfirmationFrame:SetCallback("OnClose", function(widget)
 
   end)
+  frame.ClearConfirmationFrame.statustext:GetParent():Hide()
 
   frame.ClearConfirmationFrame.label = AceGUI:Create("Label")
   frame.ClearConfirmationFrame.label:SetWidth(390)
@@ -4053,6 +4062,7 @@ function MDT:OpenConfirmationFrame(width, height, title, buttonText, prompt, cal
     f:SetLayout("Flow")
     f:SetCallback("OnClose", function(widget)
     end)
+    f.statustext:GetParent():Hide()
 
     f.label = AceGUI:Create("Label")
     f.label:SetWidth(390)


### PR DESCRIPTION
Remove the status bars from the Ace frames created, since they look out of place and even overlap other UI elements in some places.

Wasn't able to test the CustomColorFrame, because that errored out in an unrelated way.

Bit of a hack, would be better in a separate function, but the code I'm modifying is copied multiple times anyway, and if this would be split off it should be split off in a function that does more than just that, ie set title, size and layout, disables resizes etc. Maybe sth for a follow-up patch?