### PR TITLE
Update progress bar when deleting pulls

### DIFF
--- a/MythicDungeonTools.lua
+++ b/MythicDungeonTools.lua
@@ -3837,6 +3837,7 @@ function MDT:DeletePull(index)
   if #pulls == 1 then return end
   self:PresetsDeletePull(index)
   self:ReloadPullButtons()
+  MDT:UpdateProgressbar()
   local pullCount = 0
   for k, v in pairs(pulls) do
     pullCount = pullCount + 1

--- a/MythicDungeonTools.lua
+++ b/MythicDungeonTools.lua
@@ -3837,7 +3837,7 @@ function MDT:DeletePull(index)
   if #pulls == 1 then return end
   self:PresetsDeletePull(index)
   self:ReloadPullButtons()
-  MDT:UpdateProgressbar()
+  self:UpdateProgressbar()
   local pullCount = 0
   for k, v in pairs(pulls) do
     pullCount = pullCount + 1


### PR DESCRIPTION
I noticed whenever you delete a pull the count wont get updated until you hover a different pull or add/remove count. 

So i made DeletePull call UpdateProgressbar.