### PR TITLE
Add stealthdetect to Coalescing Void Diffusers in Rookery

### DIFF
--- a/TheWarWithin/TheRookery.lua
+++ b/TheWarWithin/TheRookery.lua
@@ -788,6 +788,7 @@ MDT.dungeonEnemies[dungeonIndex] = {
     ["count"] = 25,
     ["health"] = 73080370,
     ["scale"] = 1.5,
+    ["stealthDetect"] = true,
     ["displayId"] = 117974,
     ["creatureType"] = "Aberration",
     ["level"] = 80,


### PR DESCRIPTION
Coalescing Void Diffusers can detect stealth. High-level groups often execute a popular skip that involves going invisible and hugging the wall to stay out of detection range. Low- to mid-level PUGs that try to mimic this pull—after seeing experienced groups do it—often fail because they don't realize the mobs can detect stealth.