### PR TITLE
[codex] Fix restricted-environment menu taint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,5 @@
 
 Before any action, check and read ./AGENTS.local.md if it exists.
 If `AGENTS.local.md` exists, apply those rules in addition to this file. Keep `AGENTS.local.md` user-specific and uncommitted.
+
+When adding new localized strings, always add entries to both `Locales/enUS.lua` and `Locales/zhCN.lua` in the same change.

--- a/AceGUIWidgets/AceGUIWidget-MythicDungeonToolsPullButton.lua
+++ b/AceGUIWidgets/AceGUIWidget-MythicDungeonToolsPullButton.lua
@@ -125,7 +125,7 @@ local methods = {
 
     local buttonSelf = self --needed for scope issue within new context menu
     local function openSingleContextMenu()
-      MenuUtil.CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
+      MDT:CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
         if buttonSelf.index ~= 1 then
           rootDescription:CreateButton(L["Pull Drop Move up"], function()
             MDT:MovePullUp(buttonSelf.index)
@@ -216,7 +216,7 @@ local methods = {
     end
 
     local function openMultiContextMenu()
-      MenuUtil.CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
+      MDT:CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
         rootDescription:CreateButton(L["Pull Drop Insert before"], function()
           MDT.U.do_if(MDT:GetSelection(), {
             condition = function(entry)

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -4,6 +4,7 @@ local L = MDT.L
 L = L or {}
 L["MDT Legacy maps"] = "MDT Legacy maps"
 L["PREPATCH_LAUNCH_WARNING_TEXT"] = "The next expansion launches on March 3, 2026. Until then, MDT shows the next expansion dungeons by default. If you want the old dungeon maps, please install the MDT_Legacy AddOn:"
+L["Action blocked: Restricted environment"] = "Action blocked: Restricted environment"
 L["Cannot share routes right now due to blizzard restrictions."] = "Cannot share routes right now due to blizzard restrictions."
 L["exampleItemNameNoSpellId"] = "Example Item (No Spell ID)"
 L["exampleItemDescriptionNoSpellId"] = "A sample item with no associated spell ID.%s%sNew lines supported"

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -5,6 +5,7 @@ local addonName, MDT = ...
 local L = MDT.L
 L = L or {}
 -- MDT
+L["Action blocked: Restricted environment"] = "操作已被阻止：受限环境"
 L["seatItemA"] = "大多数怪物踏入虚空区域(地图边的黑水)时 会获得此BUFF"
 L["Spellwoven Familiar"] = "魔网编织魔宠"
 L["Midnight Season 1"] = "至暗之夜 第一赛季"

--- a/Modules/DungeonEnemies.lua
+++ b/Modules/DungeonEnemies.lua
@@ -206,7 +206,7 @@ local iconColors = {
 local createEnemyContextMenu = function(frame)
   MDT:GetCurrentPreset().value.enemyAssignments = MDT:GetCurrentPreset().value.enemyAssignments or {}
   local assignments = MDT:GetCurrentPreset().value.enemyAssignments
-  MenuUtil.CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
+  MDT:CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
     rootDescription:CreateTitle(L[frame.data.name])
 
     local function IsSelected(data)

--- a/Modules/FocusMarker.lua
+++ b/Modules/FocusMarker.lua
@@ -1163,7 +1163,7 @@ openMarkSettings = function()
 end
 
 local function openMarkerMenu(widget, fullName)
-  MenuUtil.CreateContextMenu(widget.frame, function(ownerRegion, rootDescription)
+  MDT:CreateContextMenu(widget.frame, function(ownerRegion, rootDescription)
     rootDescription:CreateTitle(L["Focus Marker"])
 
     for i = 1, 8 do

--- a/Modules/Pointsofinterest.lua
+++ b/Modules/Pointsofinterest.lua
@@ -66,7 +66,7 @@ local function POI_SetDevOptions(frame, poi)
 end
 
 local createPlayerAssignmentContextMenu = function(frame)
-  MenuUtil.CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
+  MDT:CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
     rootDescription:CreateTitle(L["dropdownAssignPlayer"])
 
     local group = MDT.U.GetGroupMembers()

--- a/Modules/Toolbar.lua
+++ b/Modules/Toolbar.lua
@@ -1054,7 +1054,7 @@ end
 local currentNote
 
 local function openContextMenu()
-  MenuUtil.CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
+  MDT:CreateContextMenu(MDT.main_frame, function(ownerRegion, rootDescription)
     rootDescription:CreateButton(L["Edit"], function()
       currentNote:OpenEditBox()
     end)

--- a/MythicDungeonTools.lua
+++ b/MythicDungeonTools.lua
@@ -66,6 +66,22 @@ function MDT:ShowMinimapButton()
   if MDT.main_frame and MDT.main_frame.minimapCheckbox then MDT.main_frame.minimapCheckbox:SetValue(true) end
 end
 
+---@param shouldWarn boolean|nil
+function MDT:IsInRestrictedEnvironment(shouldWarn)
+  if C_Secrets and C_Secrets.ShouldAurasBeSecret and C_Secrets.ShouldAurasBeSecret() then
+    if shouldWarn then
+      print('MDT: '..(L["Action blocked: Restricted environment"] or "Action blocked: Restricted environment"))
+    end
+    return true
+  end
+  return false
+end
+
+function MDT:CreateContextMenu(ownerRegion, generator, ...)
+  if self:IsInRestrictedEnvironment(true) then return end
+  return MenuUtil.CreateContextMenu(ownerRegion, generator, ...)
+end
+
 ---@diagnostic disable: missing-fields
 local LDB = LibStub("LibDataBroker-1.1"):NewDataObject("MythicDungeonTools", {
   type = "data source",
@@ -1146,10 +1162,7 @@ function MDT:MakeSidePanel(frame)
   frame.LinkToChatButton.frame:SetHighlightFontObject(fontInstance)
   frame.LinkToChatButton.frame:SetDisabledFontObject(fontInstance)
   frame.LinkToChatButton:SetCallback("OnClick", function(widget, callbackName, value)
-    if C_Secrets and C_Secrets.ShouldAurasBeSecret() then
-      print('MDT: '..L["Cannot share routes right now due to blizzard restrictions."])
-      return
-    end
+    if MDT:IsInRestrictedEnvironment(true) then return end
     local distribution = MDT:IsPlayerInGroup()
     if not distribution then return end
     local callback = function()
@@ -1188,10 +1201,7 @@ function MDT:MakeSidePanel(frame)
   local c1, c2, c3 = frame.LiveSessionButton.text:GetTextColor()
   frame.LiveSessionButton.normalTextColor = { r = c1, g = c2, b = c3, }
   frame.LiveSessionButton:SetCallback("OnClick", function(widget, callbackName, value)
-    if C_Secrets and C_Secrets.ShouldAurasBeSecret() then
-      print('MDT: '..L["Cannot share routes right now due to blizzard restrictions."])
-      return
-    end
+    if MDT:IsInRestrictedEnvironment(true) then return end
     if MDT.liveSessionActive then
       MDT:LiveSession_Disable()
     else


### PR DESCRIPTION
## Summary
- Add an MDT restricted-environment gate using `C_Secrets.ShouldAurasBeSecret()`.
- Route MDT-owned Blizzard context menu creation through a guarded helper.
- Add localized restricted-environment text for enUS and zhCN, plus an agent rule to keep both locales updated.

## Why
Opening MDT context menus while secrets are locked down can taint Blizzard's shared menu system. A later UnitPopup raid marker submenu then compares `GetRaidTargetIndex()` secret values from tainted execution and triggers the Lua warning from issue #712.

## Validation
- `git diff --check`
- `luac -p MythicDungeonTools.lua AceGUIWidgets/AceGUIWidget-MythicDungeonToolsPullButton.lua Modules/DungeonEnemies.lua Modules/FocusMarker.lua Modules/Pointsofinterest.lua Modules/Toolbar.lua Locales/enUS.lua Locales/zhCN.lua`