### PR TITLE
[codex] Add Xal'atath voice mute setting

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -19,6 +19,7 @@ L["exampleItemDescriptionWithSpellId"] = "A sample item that references a spell 
 L["Maps"] = "Maps"
 L["Macros"] = "Macros"
 L["Marks"] = "Marks"
+L["Mute Xal'atath Voice Lines"] = "Mute Xal'atath Voice Lines"
 L["Combat Logging"] = "Combat Logging"
 L["combatLoggingAdvancedNote"] = "Advanced combat logging is enabled automatically while combat logging is enabled."
 L["combatLoggingDungeons"] = "Dungeons"

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -8,6 +8,7 @@ L = L or {}
 L["Maps"] = "Maps"
 L["Macros"] = "Macros"
 L["Marks"] = "Marks"
+L["Mute Xal'atath Voice Lines"] = "静音 Xal'atath 语音台词"
 L["Combat Logging"] = "战斗日志"
 L["combatLoggingAdvancedNote"] = "启用战斗日志时会自动开启高级战斗日志。"
 L["combatLoggingDungeons"] = "地下城"

--- a/Modules/Settings.lua
+++ b/Modules/Settings.lua
@@ -255,6 +255,18 @@ function MDT:MakeSettingsFrame(frame)
   end)
   frame.settingsGeneralColumn:AddChild(frame.alwaysOverwriteRoutesByUIDCheckbox)
 
+  frame.muteXalatathVoiceLinesCheckbox = AceGUI:Create("CheckBox")
+  frame.muteXalatathVoiceLinesCheckbox:SetLabel(L["Mute Xal'atath Voice Lines"])
+  frame.muteXalatathVoiceLinesCheckbox:SetWidth(settingWidth)
+  frame.muteXalatathVoiceLinesCheckbox:SetValue(db.muteXalatathVoiceLines == true)
+  frame.muteXalatathVoiceLinesCheckbox:SetCallback("OnValueChanged", function(widget, callbackName, value)
+    db.muteXalatathVoiceLines = value
+    MDT:SetXalatathVoiceLinesMuted(value)
+  end)
+  if MDT:IsRetail() then
+    frame.settingsGeneralColumn:AddChild(frame.muteXalatathVoiceLinesCheckbox)
+  end
+
   -- Initialize database values if they don't exist
   if db.fadeOutDuringCombat == nil then db.fadeOutDuringCombat = false end
   if db.fadeOutAlpha == nil then db.fadeOutAlpha = 0.5 end

--- a/Modules/Xalatathmuter.lua
+++ b/Modules/Xalatathmuter.lua
@@ -1,0 +1,24 @@
+local _, MDT = ...
+
+local xalatathSoundFileIds = {
+  1391165, 1391166, 2530794, 2530796, 2530797, 2530798, 2530811, 2530835, 5770084, 5770087, 5834632, 5835211,
+  5835212, 5835214, 5835215, 5835725, 5835726, 5854705, 5859141, 6178475, 6178476, 6178477, 6178478, 6178479,
+  6178480, 6178481, 6178488, 6178489, 6178494, 6178497, 6178498, 6178500, 6178502, 6178504, 6178506, 6178508,
+}
+
+function MDT:SetXalatathVoiceLinesMuted(muted)
+  if not MDT:IsRetail() then return end
+
+  local updateSoundFile = muted and MuteSoundFile or UnmuteSoundFile
+
+  for _, soundFileId in ipairs(xalatathSoundFileIds) do
+    updateSoundFile(soundFileId)
+  end
+end
+
+function MDT:ApplyXalatathVoiceLinesMute()
+  local db = MDT:GetDB()
+  if db.muteXalatathVoiceLines then
+    MDT:SetXalatathVoiceLinesMuted(true)
+  end
+end

--- a/Modules/load_modules.xml
+++ b/Modules/load_modules.xml
@@ -10,6 +10,7 @@
 	<Script file='NavigationSidebar.lua'/>
 	<Script file='FocusMarker.lua'/>
 	<Script file='CombatLogging.lua'/>
+	<Script file='Xalatathmuter.lua'/>
 	<Script file='Settings.lua'/>
 	<Script file='LiveSession.lua'/>
 	<Script file='Maximize.lua'/>

--- a/MythicDungeonTools.lua
+++ b/MythicDungeonTools.lua
@@ -162,6 +162,7 @@ local defaultSavedVars = {
     enemyForcesFormat = 2,
     useForcesCount = false, -- replaces percent in pull buttons with count
     enemyForcesTooltip = 1,
+    muteXalatathVoiceLines = false,
     enemyStyle = 1,
     currentDifficulty = 10,
     xoffset = -80,
@@ -301,6 +302,7 @@ do
       if db and not db.minimap.hide then
         minimapIcon:Refresh("MythicDungeonTools", db.minimap)
       end
+      MDT:ApplyXalatathVoiceLinesMute()
       if db.loadOnStartUp and db.devMode then MDT:Async(function() MDT:ShowInterfaceInternal(true) end, "showInterface") end
     end)
     eventFrame:UnregisterEvent("PLAYER_ENTERING_WORLD")


### PR DESCRIPTION
## Summary
- Add a General settings checkbox to mute Xal'atath voice lines.
- Add a small Xalatathmuter module that mutes the same sound file IDs as the Xal'atath Muter addon.
- Add enUS and zhCN locale entries.

## Validation
- `luac -p Modules/Xalatathmuter.lua Modules/Settings.lua MythicDungeonTools.lua Locales/enUS.lua Locales/zhCN.lua`
- `git diff --check`